### PR TITLE
Added DateTime->isAtMidnight methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - Renamed `$monthOfYear` to `$month` in `Month`.
 - Renamed `$dayOfMonth` to `$day` in `Date`.
-- Added `isAtMidnight` in `DateTime`.
-- Added `isNotAtMidnight` in `DateTime`.
+- Added `isAtMidnight()` in `DateTime`.
+- Added `isNotAtMidnight()` in `DateTime`.
 - Added `isAtMidnightInTimeZone(\DateTimeZone $timeZone)` in `DateTime`.
 - Added `isNotAtMidnightInTimeZone(\DateTimeZone $timeZone)` in `DateTime`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Renamed `$monthOfYear` to `$month` in `Month`.
 - Renamed `$dayOfMonth` to `$day` in `Date`.
+- Added `isAtMidnight` in `DateTime`.
+- Added `isNotAtMidnight` in `DateTime`.
+- Added `isAtMidnightInTimeZone(\DateTimeZone $timeZone)` in `DateTime`.
+- Added `isNotAtMidnightInTimeZone(\DateTimeZone $timeZone)` in `DateTime`.
 
 ## 0.2.0
 

--- a/src/DateTime.php
+++ b/src/DateTime.php
@@ -132,6 +132,34 @@ final class DateTime implements \Stringable
         return $this->dateTime <=> $dateTime->dateTime;
     }
 
+    public function isAtMidnight(): bool
+    {
+        return $this
+            ->time()
+            ->isMidnight();
+    }
+
+    public function isNotAtMidnight(): bool
+    {
+        return $this
+            ->time()
+            ->isNotMidnight();
+    }
+
+    public function isAtMidnightInTimeZone(\DateTimeZone $timeZone): bool
+    {
+        return $this
+            ->timeInTimeZone($timeZone)
+            ->isMidnight();
+    }
+
+    public function isNotAtMidnightInTimeZone(\DateTimeZone $timeZone): bool
+    {
+        return $this
+            ->timeInTimeZone($timeZone)
+            ->isNotMidnight();
+    }
+
     // -- Modifications
 
     public function modify(string $modifier): self

--- a/tests/DateTimeIsAtMidnightInTimeZoneTest.php
+++ b/tests/DateTimeIsAtMidnightInTimeZoneTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimeParts;
+
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimeParts\DateTime */
+final class DateTimeIsAtMidnightInTimeZoneTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::isAtMidnightInTimeZone
+     */
+    public function is_at_midnight_in_time_zone_works(
+        bool $expectedResult,
+        DateTime $dateTime,
+        \DateTimeZone $timeZone,
+    ): void {
+        // -- Act & Assert
+        self::assertSame($expectedResult, $dateTime->isAtMidnightInTimeZone($timeZone));
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: bool,
+     *   1: DateTime,
+     *   2: \DateTimeZone,
+     * }>
+     */
+    public function dataProvider(): array
+    {
+        return [
+            'midnight at 00:00:00 in UTC' => [
+                true,
+                DateTime::fromString('2022-10-08 00:00:00'),
+                new \DateTimeZone('UTC'),
+            ],
+            'not midnight at 01:00:00 in UTC' => [
+                false,
+                DateTime::fromString('2022-01-01 01:00:00'),
+                new \DateTimeZone('UTC'),
+            ],
+            'not midnight on time with milliseconds in UTC' => [
+                false,
+                DateTime::fromString('2022-10-08 00:00:00.023423'),
+                new \DateTimeZone('UTC'),
+            ],
+            'midnight in specific timezone' => [
+                true,
+                DateTime::fromStringInTimeZone('2022-10-08 00:00:00', new \DateTimeZone('Europe/Berlin')),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+            'not midnight in specific timezone' => [
+                false,
+                DateTime::fromString('2022-10-08 00:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+        ];
+    }
+}

--- a/tests/DateTimeIsAtMidnightTest.php
+++ b/tests/DateTimeIsAtMidnightTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimeParts;
+
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimeParts\DateTime */
+final class DateTimeIsAtMidnightTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::isAtMidnight
+     */
+    public function is_at_midnight_works(
+        bool $expectedResult,
+        DateTime $dateTime,
+    ): void {
+        // -- Act & Assert
+        self::assertSame($expectedResult, $dateTime->isAtMidnight());
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: bool,
+     *   1: DateTime,
+     * }>
+     */
+    public function dataProvider(): array
+    {
+        return [
+            'midnight at 00:00:00' => [
+                true,
+                DateTime::fromString('2022-10-08 00:00:00'),
+            ],
+            'not midnight at 01:00:00' => [
+                false,
+                DateTime::fromString('2022-01-01 01:00:00'),
+            ],
+            'not midnight on time with milliseconds' => [
+                false,
+                DateTime::fromString('2022-10-08 00:00:00.023423'),
+            ],
+            'midnight in specific timezone' => [
+                true,
+                DateTime::fromStringInTimeZone('2022-10-08 00:00:00', new \DateTimeZone('Europe/Berlin'))
+                    ->toTimeZone(new \DateTimeZone('Europe/Berlin')),
+            ],
+        ];
+    }
+}

--- a/tests/DateTimeIsNotAtMidnightInTimeZoneTest.php
+++ b/tests/DateTimeIsNotAtMidnightInTimeZoneTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimeParts;
+
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimeParts\DateTime */
+final class DateTimeIsNotAtMidnightInTimeZoneTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::isNotAtMidnightInTimeZone
+     */
+    public function is_not_at_midnight_in_time_zone_works(
+        bool $expectedResult,
+        DateTime $dateTime,
+        \DateTimeZone $timeZone,
+    ): void {
+        // -- Act & Assert
+        self::assertSame($expectedResult, $dateTime->isNotAtMidnightInTimeZone($timeZone));
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: bool,
+     *   1: DateTime,
+     *   2: \DateTimeZone,
+     * }>
+     */
+    public function dataProvider(): array
+    {
+        return [
+            'midnight at 00:00:00 in UTC' => [
+                false,
+                DateTime::fromString('2022-10-08 00:00:00'),
+                new \DateTimeZone('UTC'),
+            ],
+            'not midnight at 01:00:00 in UTC' => [
+                true,
+                DateTime::fromString('2022-01-01 01:00:00'),
+                new \DateTimeZone('UTC'),
+            ],
+            'not midnight on time with milliseconds in UTC' => [
+                true,
+                DateTime::fromString('2022-10-08 00:00:00.023423'),
+                new \DateTimeZone('UTC'),
+            ],
+            'midnight in specific timezone' => [
+                false,
+                DateTime::fromStringInTimeZone('2022-10-08 00:00:00', new \DateTimeZone('Europe/Berlin')),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+            'not midnight in specific timezone' => [
+                true,
+                DateTime::fromString('2022-10-08 00:00:00'),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+        ];
+    }
+}

--- a/tests/DateTimeIsNotAtMidnightTest.php
+++ b/tests/DateTimeIsNotAtMidnightTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimeParts;
+
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimeParts\DateTime */
+final class DateTimeIsNotAtMidnightTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::isNotAtMidnight
+     */
+    public function is_not_at_midnight_works(
+        bool $expectedResult,
+        DateTime $dateTime,
+    ): void {
+        // -- Act & Assert
+        self::assertSame($expectedResult, $dateTime->isNotAtMidnight());
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: bool,
+     *   1: DateTime,
+     * }>
+     */
+    public function dataProvider(): array
+    {
+        return [
+            'midnight at 00:00:00' => [
+                false,
+                DateTime::fromString('2022-10-08 00:00:00'),
+            ],
+            'not midnight at 01:00:00' => [
+                true,
+                DateTime::fromString('2022-01-01 01:00:00'),
+            ],
+            'not midnight on time with milliseconds' => [
+                true,
+                DateTime::fromString('2022-10-08 00:00:00.023423'),
+            ],
+            'midnight in specific timezone' => [
+                false,
+                DateTime::fromStringInTimeZone('2022-10-08 00:00:00', new \DateTimeZone('Europe/Berlin'))
+                    ->toTimeZone(new \DateTimeZone('Europe/Berlin')),
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## Changelog

- Added `isAtMidnight()` in `DateTime`.
- Added `isNotAtMidnight()` in `DateTime`.
- Added `isAtMidnightInTimeZone(\DateTimeZone $timeZone)` in `DateTime`.
- Added `isNotAtMidnightInTimeZone(\DateTimeZone $timeZone)` in `DateTime`.

Resolves #11 