### PR TITLE
Add DateTime->isDate*InTimeZone

### DIFF
--- a/src/DateTime.php
+++ b/src/DateTime.php
@@ -132,6 +132,41 @@ final class DateTime implements \Stringable
         return $this->dateTime <=> $dateTime->dateTime;
     }
 
+    public function isDateAfterInTimeZone(self $dateTime, \DateTimeZone $timeZone): bool
+    {
+        return $this->dateInTimeZone($timeZone)->isAfter(
+            $dateTime->dateInTimeZone($timeZone),
+        );
+    }
+
+    public function isDateAfterOrEqualToInTimeZone(self $dateTime, \DateTimeZone $timeZone): bool
+    {
+        return $this->dateInTimeZone($timeZone)->isAfterOrEqualTo(
+            $dateTime->dateInTimeZone($timeZone),
+        );
+    }
+
+    public function isDateEqualToInTimeZone(self $dateTime, \DateTimeZone $timeZone): bool
+    {
+        return $this->dateInTimeZone($timeZone)->isEqualTo(
+            $dateTime->dateInTimeZone($timeZone),
+        );
+    }
+
+    public function isDateBeforeInTimeZone(self $dateTime, \DateTimeZone $timeZone): bool
+    {
+        return $this->dateInTimeZone($timeZone)->isBefore(
+            $dateTime->dateInTimeZone($timeZone),
+        );
+    }
+
+    public function isDateBeforeOrEqualToInTimeZone(self $dateTime, \DateTimeZone $timeZone): bool
+    {
+        return $this->dateInTimeZone($timeZone)->isBeforeOrEqualTo(
+            $dateTime->dateInTimeZone($timeZone),
+        );
+    }
+
     public function isAtMidnight(): bool
     {
         return $this

--- a/tests/DateTimeIsDateAfterInTimeZoneTest.php
+++ b/tests/DateTimeIsDateAfterInTimeZoneTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimeParts;
+
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimeParts\DateTime */
+final class DateTimeIsDateAfterInTimeZoneTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::isDateAfterInTimeZone
+     */
+    public function is_date_after_in_time_zone_works(
+        bool $expectedResult,
+        DateTime $dateTime,
+        DateTime $comparator,
+        \DateTimeZone $timeZone,
+    ): void {
+        // -- Act & Assert
+        self::assertSame($expectedResult, $dateTime->isDateAfterInTimeZone($comparator, $timeZone));
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: boolean,
+     *   1: DateTime,
+     *   2: DateTime,
+     *   3: \DateTimeZone
+     * }>
+     */
+    public function dataProvider(): array
+    {
+        return [
+            'previous day in UTC' => [
+                false,
+                DateTime::fromString('2022-10-07 00:00:00'),
+                DateTime::fromString('2022-10-08 15:00:00'),
+                new \DateTimeZone('UTC'),
+            ],
+            'previous day in Europe/Berlin' => [
+                false,
+                DateTime::fromStringInTimeZone('2022-10-07 00:00:00', new \DateTimeZone('Europe/Berlin')),
+                DateTime::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+            'next day in UTC' => [
+                true,
+                DateTime::fromString('2022-10-08 00:00:00'),
+                DateTime::fromString('2022-10-07 15:00:00'),
+                new \DateTimeZone('UTC'),
+            ],
+            'next day in Europe/Berlin' => [
+                true,
+                DateTime::fromStringInTimeZone('2022-10-08 00:00:00', new \DateTimeZone('Europe/Berlin')),
+                DateTime::fromStringInTimeZone('2022-10-07 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+            'next day in Europe/Berlin when partially in Europe/Berlin' => [
+                true,
+                DateTime::fromStringInTimeZone('2022-10-08 00:00:00', new \DateTimeZone('Europe/Berlin')),
+                DateTime::fromStringInTimeZone('2022-10-07 15:00:00', new \DateTimeZone('Europe/Berlin'))
+                    ->toTimeZone(new \DateTimeZone('Europe/Berlin')),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+        ];
+    }
+}

--- a/tests/DateTimeIsDateAfterOrEqualToInTimeZoneTest.php
+++ b/tests/DateTimeIsDateAfterOrEqualToInTimeZoneTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimeParts;
+
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimeParts\DateTime */
+final class DateTimeIsDateAfterOrEqualToInTimeZoneTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::isDateAfterOrEqualToInTimeZone
+     */
+    public function is_date_after_or_equal_to_in_time_zone_works(
+        bool $expectedResult,
+        DateTime $dateTime,
+        DateTime $comparator,
+        \DateTimeZone $timeZone,
+    ): void {
+        // -- Act & Assert
+        self::assertSame($expectedResult, $dateTime->isDateAfterOrEqualToInTimeZone($comparator, $timeZone));
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: boolean,
+     *   1: DateTime,
+     *   2: DateTime,
+     *   3: \DateTimeZone
+     * }>
+     */
+    public function dataProvider(): array
+    {
+        return [
+            'previous day in UTC' => [
+                false,
+                DateTime::fromString('2022-10-07 00:00:00'),
+                DateTime::fromString('2022-10-08 15:00:00'),
+                new \DateTimeZone('UTC'),
+            ],
+            'previous day in Europe/Berlin' => [
+                false,
+                DateTime::fromStringInTimeZone('2022-10-07 00:00:00', new \DateTimeZone('Europe/Berlin')),
+                DateTime::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+            'same day in UTC' => [
+                true,
+                DateTime::fromString('2022-10-08 00:00:00'),
+                DateTime::fromString('2022-10-08 15:00:00'),
+                new \DateTimeZone('UTC'),
+            ],
+            'same day in Europe/Berlin' => [
+                true,
+                DateTime::fromStringInTimeZone('2022-10-08 00:00:00', new \DateTimeZone('Europe/Berlin')),
+                DateTime::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+            'next day in UTC' => [
+                true,
+                DateTime::fromString('2022-10-08 00:00:00'),
+                DateTime::fromString('2022-10-07 15:00:00'),
+                new \DateTimeZone('UTC'),
+            ],
+            'next day in Europe/Berlin' => [
+                true,
+                DateTime::fromStringInTimeZone('2022-10-08 00:00:00', new \DateTimeZone('Europe/Berlin')),
+                DateTime::fromStringInTimeZone('2022-10-07 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+            'next day in Europe/Berlin when partially in Europe/Berlin' => [
+                true,
+                DateTime::fromStringInTimeZone('2022-10-08 00:00:00', new \DateTimeZone('Europe/Berlin')),
+                DateTime::fromStringInTimeZone('2022-10-07 15:00:00', new \DateTimeZone('Europe/Berlin'))
+                    ->toTimeZone(new \DateTimeZone('Europe/Berlin')),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+        ];
+    }
+}

--- a/tests/DateTimeIsDateBeforeInTimeZoneTest.php
+++ b/tests/DateTimeIsDateBeforeInTimeZoneTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimeParts;
+
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimeParts\DateTime */
+final class DateTimeIsDateBeforeInTimeZoneTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::isDateBeforeInTimeZone
+     */
+    public function is_date_before_in_time_zone_works(
+        bool $expectedResult,
+        DateTime $dateTime,
+        DateTime $comparator,
+        \DateTimeZone $timeZone,
+    ): void {
+        // -- Act & Assert
+        self::assertSame($expectedResult, $dateTime->isDateBeforeInTimeZone($comparator, $timeZone));
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: boolean,
+     *   1: DateTime,
+     *   2: DateTime,
+     *   3: \DateTimeZone
+     * }>
+     */
+    public function dataProvider(): array
+    {
+        return [
+            'previous day in UTC' => [
+                true,
+                DateTime::fromString('2022-10-07 00:00:00'),
+                DateTime::fromString('2022-10-08 15:00:00'),
+                new \DateTimeZone('UTC'),
+            ],
+            'previous day in Europe/Berlin' => [
+                true,
+                DateTime::fromStringInTimeZone('2022-10-07 00:00:00', new \DateTimeZone('Europe/Berlin')),
+                DateTime::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+            'previous day in Europe/Berlin when partially in Europe/Berlin' => [
+                true,
+                DateTime::fromStringInTimeZone('2022-10-07 00:00:00', new \DateTimeZone('Europe/Berlin')),
+                DateTime::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin'))
+                    ->toTimeZone(new \DateTimeZone('Europe/Berlin')),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+            'next day in UTC' => [
+                false,
+                DateTime::fromString('2022-10-08 00:00:00'),
+                DateTime::fromString('2022-10-07 15:00:00'),
+                new \DateTimeZone('UTC'),
+            ],
+            'next day in Europe/Berlin' => [
+                false,
+                DateTime::fromStringInTimeZone('2022-10-08 00:00:00', new \DateTimeZone('Europe/Berlin')),
+                DateTime::fromStringInTimeZone('2022-10-07 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+        ];
+    }
+}

--- a/tests/DateTimeIsDateBeforeOrEqualToInTimeZoneTest.php
+++ b/tests/DateTimeIsDateBeforeOrEqualToInTimeZoneTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimeParts;
+
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimeParts\DateTime */
+final class DateTimeIsDateBeforeOrEqualToInTimeZoneTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::isDateBeforeOrEqualToInTimeZone
+     */
+    public function is_date_before_or_equal_to_in_time_zone_works(
+        bool $expectedResult,
+        DateTime $dateTime,
+        DateTime $comparator,
+        \DateTimeZone $timeZone,
+    ): void {
+        // -- Act & Assert
+        self::assertSame($expectedResult, $dateTime->isDateBeforeOrEqualToInTimeZone($comparator, $timeZone));
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: boolean,
+     *   1: DateTime,
+     *   2: DateTime,
+     *   3: \DateTimeZone
+     * }>
+     */
+    public function dataProvider(): array
+    {
+        return [
+            'previous day in UTC' => [
+                true,
+                DateTime::fromString('2022-10-07 00:00:00'),
+                DateTime::fromString('2022-10-08 15:00:00'),
+                new \DateTimeZone('UTC'),
+            ],
+            'previous day in Europe/Berlin' => [
+                true,
+                DateTime::fromStringInTimeZone('2022-10-07 00:00:00', new \DateTimeZone('Europe/Berlin')),
+                DateTime::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+            'previous day in Europe/Berlin when partially in Europe/Berlin' => [
+                true,
+                DateTime::fromStringInTimeZone('2022-10-07 00:00:00', new \DateTimeZone('Europe/Berlin')),
+                DateTime::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin'))
+                    ->toTimeZone(new \DateTimeZone('Europe/Berlin')),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+            'same day in UTC' => [
+                true,
+                DateTime::fromString('2022-10-08 00:00:00'),
+                DateTime::fromString('2022-10-08 15:00:00'),
+                new \DateTimeZone('UTC'),
+            ],
+            'same day in Europe/Berlin' => [
+                true,
+                DateTime::fromStringInTimeZone('2022-10-08 00:00:00', new \DateTimeZone('Europe/Berlin')),
+                DateTime::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+            'next day in UTC' => [
+                false,
+                DateTime::fromString('2022-10-08 00:00:00'),
+                DateTime::fromString('2022-10-07 15:00:00'),
+                new \DateTimeZone('UTC'),
+            ],
+            'next day in Europe/Berlin' => [
+                false,
+                DateTime::fromStringInTimeZone('2022-10-08 00:00:00', new \DateTimeZone('Europe/Berlin')),
+                DateTime::fromStringInTimeZone('2022-10-07 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+        ];
+    }
+}

--- a/tests/DateTimeIsDateEqualToInTimeZoneTest.php
+++ b/tests/DateTimeIsDateEqualToInTimeZoneTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DigitalCraftsman\DateTimeParts;
+
+use PHPUnit\Framework\TestCase;
+
+/** @coversDefaultClass \DigitalCraftsman\DateTimeParts\DateTime */
+final class DateTimeIsDateEqualToInTimeZoneTest extends TestCase
+{
+    /**
+     * @test
+     *
+     * @dataProvider dataProvider
+     *
+     * @covers ::isDateEqualToInTimeZone
+     */
+    public function is_date_equal_to_in_time_zone_works(
+        bool $expectedResult,
+        DateTime $dateTime,
+        DateTime $comparator,
+        \DateTimeZone $timeZone,
+    ): void {
+        // -- Act & Assert
+        self::assertSame($expectedResult, $dateTime->isDateEqualToInTimeZone($comparator, $timeZone));
+    }
+
+    /**
+     * @return array<string, array{
+     *   0: boolean,
+     *   1: DateTime,
+     *   2: DateTime,
+     *   3: \DateTimeZone
+     * }>
+     */
+    public function dataProvider(): array
+    {
+        return [
+            'previous day in UTC' => [
+                false,
+                DateTime::fromString('2022-10-07 00:00:00'),
+                DateTime::fromString('2022-10-08 15:00:00'),
+                new \DateTimeZone('UTC'),
+            ],
+            'previous day in Europe/Berlin' => [
+                false,
+                DateTime::fromStringInTimeZone('2022-10-07 00:00:00', new \DateTimeZone('Europe/Berlin')),
+                DateTime::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+            'same day in UTC' => [
+                true,
+                DateTime::fromString('2022-10-08 00:00:00'),
+                DateTime::fromString('2022-10-08 15:00:00'),
+                new \DateTimeZone('UTC'),
+            ],
+            'same day in Europe/Berlin' => [
+                true,
+                DateTime::fromStringInTimeZone('2022-10-08 00:00:00', new \DateTimeZone('Europe/Berlin')),
+                DateTime::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+            'same day in Europe/Berlin when partially in Europe/Berlin' => [
+                true,
+                DateTime::fromStringInTimeZone('2022-10-08 00:00:00', new \DateTimeZone('Europe/Berlin')),
+                DateTime::fromStringInTimeZone('2022-10-08 15:00:00', new \DateTimeZone('Europe/Berlin'))
+                    ->toTimeZone(new \DateTimeZone('Europe/Berlin')),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+            'next day in UTC' => [
+                false,
+                DateTime::fromString('2022-10-08 00:00:00'),
+                DateTime::fromString('2022-10-07 15:00:00'),
+                new \DateTimeZone('UTC'),
+            ],
+            'next day in Europe/Berlin' => [
+                false,
+                DateTime::fromStringInTimeZone('2022-10-08 00:00:00', new \DateTimeZone('Europe/Berlin')),
+                DateTime::fromStringInTimeZone('2022-10-07 15:00:00', new \DateTimeZone('Europe/Berlin')),
+                new \DateTimeZone('Europe/Berlin'),
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
## Changes

- Added `isDateAfterInTimeZone(DateTime $dateTime, \DateTimeZone $timeZone): bool` in `DateTime`.
- Added `isDateAfterOrEqualToInTimeZone(DateTime $dateTime, \DateTimeZone $timeZone): bool` in `DateTime`.
- Added `isDateEqualToInTimeZone(DateTime $dateTime, \DateTimeZone $timeZone): bool` in `DateTime`.
- Added `isDateBeforeInTimeZone(DateTime $dateTime, \DateTimeZone $timeZone): bool` in `DateTime`.
- Added `isDateBeforeOrEqualToInTimeZone(DateTime $dateTime, \DateTimeZone $timeZone): bool` in `DateTime`.